### PR TITLE
Add optional nonblocking locking

### DIFF
--- a/Classes/FlockLockStrategy.php
+++ b/Classes/FlockLockStrategy.php
@@ -64,16 +64,17 @@ class FlockLockStrategy implements LockStrategyInterface
     /**
      * @param string $subject
      * @param boolean $exclusiveLock true to, acquire an exclusive (write) lock, false for a shared (read) lock.
+     * @param boolean $nonblocking true to, acquire the lock in nonblocking mode, false for a blocking lock lock.
      * @return void
      * @throws LockNotAcquiredException
      */
-    public function acquire(string $subject, bool $exclusiveLock)
+    public function acquire(string $subject, bool $exclusiveLock, bool $nonblocking = false)
     {
         $this->lockFileName = Utility\Files::concatenatePaths([$this->temporaryDirectory, md5($subject)]);
         $aquiredLock = false;
         $i = 0;
         while ($aquiredLock === false) {
-            $aquiredLock = $this->tryToAcquireLock($exclusiveLock);
+            $aquiredLock = $this->tryToAcquireLock($exclusiveLock, $nonblocking);
             $i++;
             if ($i > 10000) {
                 throw new LockNotAcquiredException(sprintf('After 10000 attempts a lock could not be aquired for subject "%s".', $subject), 1449829188);
@@ -98,17 +99,18 @@ class FlockLockStrategy implements LockStrategyInterface
      * Tries to open a lock file and apply the lock to it.
      *
      * @param boolean $exclusiveLock
+     * @param boolean $nonblocking
      * @return boolean Was a lock aquired?
      * @throws LockNotAcquiredException
      */
-    protected function tryToAcquireLock(bool $exclusiveLock): bool
+    protected function tryToAcquireLock(bool $exclusiveLock, bool $nonblocking): bool
     {
         $this->filePointer = @fopen($this->lockFileName, 'w');
         if ($this->filePointer === false) {
             throw new LockNotAcquiredException(sprintf('Lock file "%s" could not be opened', $this->lockFileName), 1386520596);
         }
 
-        $this->applyFlock($exclusiveLock);
+        $this->applyFlock($exclusiveLock, $nonblocking);
 
         $fstat = fstat($this->filePointer);
         $stat = @stat($this->lockFileName);
@@ -130,11 +132,15 @@ class FlockLockStrategy implements LockStrategyInterface
      * apply flock to the opened lock file.
      *
      * @param boolean $exclusiveLock
+     * @param boolean $nonblocking
      * @throws LockNotAcquiredException
      */
-    protected function applyFlock(bool $exclusiveLock)
+    protected function applyFlock(bool $exclusiveLock, bool $nonblocking)
     {
         $lockOption = $exclusiveLock === true ? LOCK_EX : LOCK_SH;
+        if($nonblocking){
+            $lockOption |= LOCK_NB;
+        }
 
         if (flock($this->filePointer, $lockOption) !== true) {
             throw new LockNotAcquiredException(sprintf('Could not lock file "%s"', $this->lockFileName), 1386520597);

--- a/Classes/LockStrategyInterface.php
+++ b/Classes/LockStrategyInterface.php
@@ -21,9 +21,10 @@ interface LockStrategyInterface
     /**
      * @param string $subject
      * @param boolean $exclusiveLock true to, acquire an exclusive (write) lock, false for a shared (read) lock.
+     * @param boolean $nonblocking true to, acquire the lock in nonblocking mode, false for a blocking lock lock.
      * @return void
      */
-    public function acquire(string $subject, bool $exclusiveLock);
+    public function acquire(string $subject, bool $exclusiveLock, bool $nonblocking = false);
 
     /**
      * @return boolean true on success, false otherwise


### PR DESCRIPTION
I added an optional parameter for nonblocking locks. If the lock could not be acquired, the method `applyFlock` throws an Exception.

Before this non blocking feature, it was not possible, that `applyFlock` throws an Exception, since flock blocked and thus always returned true. So this is kind of a bug in the expected interface of the implementation.