### PR TITLE
TASK: Allow PHP 8.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "homepage": "http://flow.neos.io",
   "license": "MIT",
   "require": {
-    "php": "^7.2",
+    "php": "^7.2 || php ^8.0",
     "neos/flow": "*",
     "neos/utility-files": "*"
   },

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "homepage": "http://flow.neos.io",
   "license": "MIT",
   "require": {
-    "php": "^7.2 || php ^8.0",
+    "php": "^7.2 || ^8.0",
     "neos/flow": "*",
     "neos/utility-files": "*"
   },


### PR DESCRIPTION
The package `ttree/scheduler` uses this package for locks, but cannot be installed in Neos 8.x because Neos requires PHP 8. This PR should help fix this.